### PR TITLE
Set the path prefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -152,5 +152,5 @@ module.exports = {
     ]
   },
   plugins: [`@adobe/gatsby-theme-aio`],
-  pathPrefix: process.env.PATH_PREFIX || '/dev-site-documentation-template/'
+  pathPrefix: process.env.PATH_PREFIX || '/experience-manager-forms-cloud-service-developer-reference/'
 };


### PR DESCRIPTION
Set the path prefix to experience-manager-forms-cloud-service-developer-reference


