### PR TITLE
Revert "Bump @adobe/gatsby-theme-aio from 4.14.4 to 4.14.12"

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/icaraps"
   },
   "dependencies": {
-    "@adobe/gatsby-theme-aio": "^4.14.18",
+    "@adobe/gatsby-theme-aio": "^4.14.4",
     "gatsby": "4.22.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12213,7 +12213,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "experience-manager-forms-cloud-service@workspace:."
   dependencies:
-    "@adobe/gatsby-theme-aio": ^4.14.18
+    "@adobe/gatsby-theme-aio": ^4.14.4
     gatsby: 4.22.0
     react: ^17.0.2
     react-dom: ^17.0.2


### PR DESCRIPTION
Reverts AdobeDocs/experience-manager-forms-cloud-service-developer-reference#145